### PR TITLE
def: Add support for Keen 6 EGA v1.5

### DIFF
--- a/def/keen6_ega_formgen_15.def
+++ b/def/keen6_ega_formgen_15.def
@@ -1,0 +1,31 @@
+#ModId definition file for Keen 6, EGA FormGen/GT release, v1.5
+GALAXY
+	GAMEEXT ck6
+	GRSTARTS 3
+	EXEINFO keen6.exe 0x3F630 0x259B0 0x36F4E 0x2C00
+	CKPATCHVER 1.5
+	CHUNKS 5560
+		FONT		3 3				#num, start
+		FONTM		0 6
+		PICS            37  6	 0      #num, start, tablestart
+		PICM            3   43 	 1
+		SPRITES         390 46   2
+		TILE8           104 436
+		TILE8M          12 437
+		TILE16          2376 438
+		TILE16M         2736 2814
+		TILE32          0 5550
+		TILE32M         0 5550
+
+		TEXT		5550 endart
+
+		B800TEXT 5551 endgame
+		TERMINATOR 5552 commander
+		TERMINATOR 5553 keen
+		B800TEXT 5554 outofmem
+
+		DEMO    	5555 0
+		DEMO    	5556 1
+		DEMO    	5557 2
+		DEMO    	5558 3
+		DEMO    	5559 4


### PR DESCRIPTION
Add a .def file for Keen6 EGA v1.5, which is now supported by CK6PATCH and other tools. This is the latest, least-buggy version of Keen 6, so probably should be used as a base from now on.